### PR TITLE
add autoconf-archive build dependency to hexchat

### DIFF
--- a/hexchat.rb
+++ b/hexchat.rb
@@ -17,6 +17,7 @@ class Hexchat < Formula
     depends_on "automake" => :build
     depends_on "autoconf" => :build
     depends_on "libtool" => :build
+    depends_on "autoconf-archive" => :build
   end
 
   option "without-perl", "Build without Perl support"
@@ -30,6 +31,7 @@ class Hexchat < Formula
   depends_on "gtk+"
   depends_on "gtk-mac-integration"
   depends_on "openssl"
+
 
   def install
     args = %W[--prefix=#{prefix}


### PR DESCRIPTION
It is needed to build hexchat from source at current HEAD (post 10.12 release); i.e. with:

````
brew install --HEAD --without-plugins homebrew-gui/hexchat
```