### PR TITLE
inkscape: Migrate to caskformula/caskformula

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -6,7 +6,7 @@
   "gtk-chtheme": "homebrew/core",
   "gtkwave": "caskroom/cask",
   "hexchat": "caskroom/cask",
-  "inkscape": "caskroom/cask",
+  "inkscape": "caskformula/caskformula",
   "klavaro": "homebrew/core",
   "meld": "caskroom/cask",
   "tarsnap-gui": "homebrew/core",


### PR DESCRIPTION
Not sure if an unofficial tap is acceptable for a migration from an official formula.

But, I think that for most users, having a drop-in replacement for the formula they were already using would be preferable to being downgraded from 0.92 to 0.91 in the cask.